### PR TITLE
Add package metadata

### DIFF
--- a/packages/eslint-config-atom/package.json
+++ b/packages/eslint-config-atom/package.json
@@ -8,8 +8,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rixo/rixo-eslint.git"
+    "url": "git+https://github.com/rixo/rixo-eslint.git",
+    "directory": "packages/eslint-config-atom"
   },
+  "homepage": "https://github.com/rixo/rixo-eslint#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint-config-svelte-native/package.json
+++ b/packages/eslint-config-svelte-native/package.json
@@ -14,7 +14,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rixo/rixo-eslint.git"
+    "url": "git+https://github.com/rixo/rixo-eslint.git",
+    "directory": "packages/eslint-config-svelte-native"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-config-svelte/package.json
+++ b/packages/eslint-config-svelte/package.json
@@ -13,7 +13,8 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rixo/rixo-eslint.git"
+    "url": "git+https://github.com/rixo/rixo-eslint.git",
+    "directory": "packages/eslint-config-svelte"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -2,6 +2,12 @@
   "name": "@rixo/eslint-config",
   "version": "0.11.0-alpha.0",
   "description": "Rixo's default eslint config",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rixo/rixo-eslint.git",
+    "directory": "packages/eslint-config"
+  },
+  "homepage": "https://github.com/rixo/rixo-eslint#readme",
   "keywords": [
     "rixo",
     "eslint",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -4,8 +4,10 @@
   "description": "Rixo's eslint & prettier default dependencies",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rixo/rixo-eslint.git"
+    "url": "git+https://github.com/rixo/rixo-eslint.git",
+    "directory": "packages/eslint"
   },
+  "homepage": "https://github.com/rixo/rixo-eslint#readme",
   "keywords": [
     "rixo",
     "eslint",


### PR DESCRIPTION
`svelte-hmr` uses one of these packages and it took me awhile to figure out where it lived on GitHub. This should help